### PR TITLE
ElementLabel is sometimes signed int, throwing InvalidCastExceptions

### DIFF
--- a/Squalr/Source/Scanners/ChangeCounter/ChangeCounterModel.cs
+++ b/Squalr/Source/Scanners/ChangeCounter/ChangeCounterModel.cs
@@ -79,7 +79,7 @@
 
                 foreach (SnapshotElementIterator element in region)
                 {
-                    element.ElementLabel = Convert.ToUInt32(element.ElementLabel) + 1;
+                    element.ElementLabel = (UInt16)((UInt16)element.ElementLabel + 1);
                 }
 
                 lock (this.ProgressLock)

--- a/Squalr/Source/Scanners/ChangeCounter/ChangeCounterModel.cs
+++ b/Squalr/Source/Scanners/ChangeCounter/ChangeCounterModel.cs
@@ -79,7 +79,7 @@
 
                 foreach (SnapshotElementIterator element in region)
                 {
-                    element.ElementLabel = (UInt16)element.ElementLabel + 1;
+                    element.ElementLabel = Convert.ToUInt32(element.ElementLabel) + 1;
                 }
 
                 lock (this.ProgressLock)


### PR DESCRIPTION
Changed cast to Convert.ToUInt32()