### PR TITLE
Fix V3031 warning from PVS-Studio Static Analyzer

### DIFF
--- a/WpfToolkit/Primitives/UpDownBase.cs
+++ b/WpfToolkit/Primitives/UpDownBase.cs
@@ -492,8 +492,7 @@ namespace Xceed.Wpf.Toolkit.Primitives
       {
         // When text is typed, if UpdateValueOnEnterKey is true, 
         // Sync Value on Text only when Enter Key is pressed.
-        if( ( _isTextChangedFromUI && !this.UpdateValueOnEnterKey )
-          || !_isTextChangedFromUI)
+        if( !_isTextChangedFromUI || !this.UpdateValueOnEnterKey )
         {
           SyncTextAndValueProperties( true, Text );
         }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3031](https://www.viva64.com/en/w/v3031/) An excessive check can be simplified. The '||' operator is surrounded by opposite expressions '_isTextChangedFromUI' and '!_isTextChangedFromUI'. UpDownBase.cs 495