### PR TITLE
Fix V3100 warning from PVS-Studio Static Analyzer

### DIFF
--- a/WpfToolkit/Zoombox/ZoomboxViewStack.cs
+++ b/WpfToolkit/Zoombox/ZoomboxViewStack.cs
@@ -529,8 +529,11 @@ namespace Xceed.Wpf.Toolkit.Zoombox
 
       public void Dispose()
       {
-        _viewStack.IsChangeFromSource = false;
-        _viewStack = null;
+        if ( _viewStack != null )
+        {
+          _viewStack.IsChangeFromSource = false;
+          _viewStack = null;
+        }
         GC.SuppressFinalize( this );
       }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3100](https://www.viva64.com/en/w/v3100/) NullReferenceException is possible when dereferencing '_viewStack' variable. Unhandled exceptions in destructor lead to termination of runtime. ZoomboxViewStack.cs 532