### PR TITLE
Fix V3108 warning from PVS-Studio Static Analyzer

### DIFF
--- a/SqualrCore/Source/Utils/DataType.cs
+++ b/SqualrCore/Source/Utils/DataType.cs
@@ -102,7 +102,7 @@
 
         public override String ToString()
         {
-            return this.Type?.ToString();
+            return this.Type?.ToString() ?? String.Empty;
         }
     }
     //// End class


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3108](https://www.viva64.com/en/w/v3108/) It is not recommended to return 'null' from 'ToSting()' method. DataType.cs 105